### PR TITLE
Do not add amd64 architecture if host is arm64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,8 +17,7 @@ Vagrant.configure('2') do |config|
 
     if is_arm64?()
         libc_package = "libc6:arm64"
-        arch_commands = "dpkg --add-architecture arm64
-                         dpkg --add-architecture amd64"
+        arch_commands = "dpkg --add-architecture arm64"
         gcc_package = "gcc-x86-64-linux-gnu"
     else
         libc_package = ""


### PR DESCRIPTION
On arm64 this makes the VM pull the wrong packages