### PR TITLE
Use config files in sample applications

### DIFF
--- a/samples/hello_elixir/config/config.exs
+++ b/samples/hello_elixir/config/config.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :hello_elixir,
+  key: "value"

--- a/samples/hello_elixir/lib/hello_elixir/application.ex
+++ b/samples/hello_elixir/lib/hello_elixir/application.ex
@@ -4,7 +4,7 @@ defmodule HelloElixir.Application do
 
   def start(_type, _args) do
     :io.format(">>>>> ~s~n", [Hello.world()])
-
+    :io.format("Config: ~p~n", [Application.get_env(:hello_elixir, :key)])
     children = []
     opts = [strategy: :one_for_one, name: HelloElixir.Supervisor]
     Supervisor.start_link(children, opts)

--- a/samples/hello_grisp/config/sys.config
+++ b/samples/hello_grisp/config/sys.config
@@ -1,1 +1,3 @@
-[{hello_grisp, []}].
+[{hello_grisp, [
+    {key, "value"}
+]}].

--- a/samples/hello_grisp/src/hello_grisp_app.erl
+++ b/samples/hello_grisp/src/hello_grisp_app.erl
@@ -11,6 +11,7 @@
 
 start(_StartType, _StartArgs) ->
     io:format(">>>>> ~s~n", [hello:world()]),
+    io:format("Config: ~p~n", [application:get_env(hello_grisp, key)]),
     hello_grisp_sup:start_link().
 
 stop(_State) ->


### PR DESCRIPTION
To allow further testing with the provided samples. 
I added a couple of dummy configurations to verify that once deployed, the apps load their configurations correctly.