### PR TITLE
change sdk path to /opt/grisp

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -144,7 +144,7 @@ GLB_SCRIPT_DIR="$(readlink_f "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 GLB_TOP_DIR="$( cd "$GLB_SCRIPT_DIR" && cd .. && pwd )"
 GLB_VAGRANT_TOP_DIR="/home/vagrant"
 GLB_SDK_NAME="grisp_alloy_sdk"
-GLB_SDK_PARENT_DIR="/opt"
+GLB_SDK_PARENT_DIR="/opt/grisp"
 GLB_SDK_BASE_DIR="${GLB_SDK_PARENT_DIR}/${GLB_SDK_NAME}"
 
 if [[ $GLB_TOP_DIR == ${GLB_SDK_BASE_DIR}* ]]; then


### PR DESCRIPTION
this allows for the user to adjust permissions on the grisp sub-path and does not force root permissions for building