### PR TITLE
Use GPT instead of MBR

### DIFF
--- a/system_common/board/grisp-common/rootfs_overlay/sbin/early-init.sh
+++ b/system_common/board/grisp-common/rootfs_overlay/sbin/early-init.sh
@@ -6,7 +6,7 @@ log() { echo "[eraly-init] $*"; }
 
 # -------- settings (override with kernel cmdline: data_dev=/dev/XYZ) --------
 
-DATA_DEV="/dev/rootdisk0p4"
+DATA_DEV=${1:-"/dev/rootdisk0p4"}
 DATA_MNT="/data"
 DATA_FS="f2fs"
 # Security/wear-friendly mount opts; adjust as needed.

--- a/system_kontron-albl-imx8mm/fwup.conf
+++ b/system_kontron-albl-imx8mm/fwup.conf
@@ -1,6 +1,6 @@
 # Firmware configuration file for Kontron AL/BL i.MX8M Mini on Linux
 
-require-fwup-version="1.0.0"
+require-fwup-version="1.4.0"
 
 #
 # Firmware metadata
@@ -27,43 +27,49 @@ define(PRIMARY_ENV_BIN, "${GRISP_SYSTEM}/images/uboot-env.bin")
 define(SECONDARY_ENV_BIN, "${GRISP_SYSTEM}/images/uboot-env.bin")
 
 # This configuration file will create an image that
-# has an MBR and the following layout:
+# uses GPT and the following layout (partition numbers):
 #
 # +----------------------------+
-# | MBR                        |
+# | Protective MBR + GPT       |
 # +----------------------------+
 # | U-Boot @ offset 33KB       |
 # +----------------------------+
-# | U-Boot Env 1 @ 1.875MB     |
-# | U-Boot Env 2 @ 1.9375MB    |
+# | U-Boot Env 1 @ 1.875 MiB   |
+# | U-Boot Env 2 @ 1.9375 MiB  |
 # +----------------------------+
-# | p0: Boot partition (FAT32) |
-# | fitImage_A, fitImage_B     |
+# | p0: Secure Enclave (resvd) |
 # +----------------------------+
-# | p1: Rootfs A (squashfs)    |
+# | p1: Boot (FAT32)           |
+# |     fitImage_A/B           |
 # +----------------------------+
-# | p2: Rootfs B (squashfs)    |
+# | p2: Rootfs A (squashfs)    |
 # +----------------------------+
-# | p3: Application (f2fs)     |
+# | p3: Rootfs B (squashfs)    |
+# +----------------------------+
+# | p4: Application (f2fs)     |
 # +----------------------------+
 
-# The U-Boot is written directly to the SDCard/eMMC at 33KB offset (IMX_BOOT_SEEK)
-define(UBOOT_OFFSET, 66)  # 33KB = 66 * 512 bytes blocks
-define(UBOOT_COUNT, 8000) # Reserve ~4MB for U-Boot
+# The U-Boot is written directly to the SDCard/eMMC at 33 KiB offset (IMX_BOOT_SEEK)
+define(UBOOT_OFFSET, 66)  # 33 KiB = 66 * 512 bytes blocks
+define(UBOOT_COUNT, 8000) # Reserve ~4 MiB for U-Boot
 
 # The U-Boot environment
 # Dual environment setup for redundancy
-define(UBOOT_ENV_PRIMARY_OFFSET, 3840)    # 1.875MB offset (0x1E0000)
-define(UBOOT_ENV_SECONDARY_OFFSET, 3968)  # 1.9375MB offset (0x1F0000)
-define(UBOOT_ENV_COUNT, 128)              # 64KB (0x10000)
+define(UBOOT_ENV_PRIMARY_OFFSET, 3840)    # 1.875 MiB offset (0x1E0000)
+define(UBOOT_ENV_SECONDARY_OFFSET, 3968)  # 1.9375 MiB offset (0x1F0000)
+define(UBOOT_ENV_COUNT, 128)              # 64 KiB (0x10000)
+
+# Reserve space for a future secure enclave at 4 MiB (before other partitions)
+define(SEC_PART_OFFSET, 8192)   # 4 MiB
+define(SEC_PART_COUNT, 262144)  # 128 MiB
 
 # The boot partition contains the fitImage files for A/B boot
-define(BOOT_PART_OFFSET, 8192)  # 4MB offset
-define(BOOT_PART_COUNT, 131072) # 64MB
+define-eval(BOOT_PART_OFFSET, "${SEC_PART_OFFSET} + ${SEC_PART_COUNT}")
+define(BOOT_PART_COUNT, 131072) # 64 MiB
 
-# Let the rootfs have room to grow up to 256MB and align it to the nearest 1MB boundary
-define(ROOTFS_A_PART_OFFSET, 139264) # 4MB + 64MB = 68MB
-define(ROOTFS_A_PART_COUNT, 524288)  # 256MB
+# Let the rootfs have room to grow up to 256 MiB and align it to the nearest 1 MiB boundary
+define-eval(ROOTFS_A_PART_OFFSET, "${BOOT_PART_OFFSET} + ${BOOT_PART_COUNT}")
+define(ROOTFS_A_PART_COUNT, 524288)  # 256 MiB
 define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
 define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
 
@@ -108,27 +114,43 @@ file-resource rootfs.img {
     assert-size-lte = ${ROOTFS_A_PART_COUNT}
 }
 
-mbr mbr {
+gpt gpt {
+    guid = 01999b2e-3fba-7508-9cd5-a58f16f5350a
+
     partition 0 {
-        block-offset = ${BOOT_PART_OFFSET}
-        block-count = ${BOOT_PART_COUNT}
-        type = 0xc # FAT32
-        boot = true
+        block-offset = ${SEC_PART_OFFSET}
+        block-count = ${SEC_PART_COUNT}
+        type = 8da63339-0007-60c0-c436-083ac8230908  # Linux reserved
+        guid = 01999b27-85c6-727c-a37b-c1838a5c93fa
+        name = "secure_enclave"
     }
     partition 1 {
-        block-offset = ${ROOTFS_A_PART_OFFSET}
-        block-count = ${ROOTFS_A_PART_COUNT}
-        type = 0x83 # Linux
+        block-offset = ${BOOT_PART_OFFSET}
+        block-count = ${BOOT_PART_COUNT}
+        type = ebd0a0a2-b9e5-4433-87c0-68b6b72699c7  # Basic data (FAT)
+        guid = 01999b27-ae3e-77eb-bc96-2b5da0810af8
+        name = "boot"
     }
     partition 2 {
-        block-offset = ${ROOTFS_B_PART_OFFSET}
-        block-count = ${ROOTFS_B_PART_COUNT}
-        type = 0x83 # Linux
+        block-offset = ${ROOTFS_A_PART_OFFSET}
+        block-count = ${ROOTFS_A_PART_COUNT}
+        type = 0fc63daf-8483-4772-8e79-3d69d8477de4  # Linux filesystem
+        guid = 01999b27-e0ca-73cf-9908-d9d1961a7df0
+        name = "rootfs_a"
     }
     partition 3 {
+        block-offset = ${ROOTFS_B_PART_OFFSET}
+        block-count = ${ROOTFS_B_PART_COUNT}
+        type = 0fc63daf-8483-4772-8e79-3d69d8477de4  # Linux filesystem
+        guid = 01999b27-fffa-74af-9f51-aafad27e9e88
+        name = "rootfs_b"
+    }
+    partition 4 {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
-        type = 0x83 # Linux
+        type = 0fc63daf-8483-4772-8e79-3d69d8477de4  # Linux filesystem
+        guid = 01999b28-1b5a-738e-9a47-649cf192b781
+        name = "data"
         expand = true
     }
 }
@@ -147,7 +169,7 @@ task complete {
 
     on-init {
         info("Initializing Kontron AL/BL i.MX8M Mini eMMC")
-        mbr_write(mbr)
+        gpt_write(gpt)
 
         fat_mkfs(${BOOT_PART_OFFSET}, ${BOOT_PART_COUNT})
         fat_setlabel(${BOOT_PART_OFFSET}, "BOOT")
@@ -230,7 +252,7 @@ task sdcard {
         info("Creating bootable SD card for Kontron AL/BL i.MX8M Mini")
 
         # Write partition table
-        mbr_write(mbr)
+        gpt_write(gpt)
 
         # Create and setup boot partition
         fat_mkfs(${BOOT_PART_OFFSET}, ${BOOT_PART_COUNT})
@@ -302,8 +324,8 @@ task sdcard {
 
 # This firmware task updates system A when system B is currently active
 task update.a {
-    # Verify we are running from system B
-    require-partition-offset(1, ${ROOTFS_B_PART_OFFSET})
+    # Verify we are running from system B (rootfs_b is partition index 3)
+    require-partition-offset(3, ${ROOTFS_B_PART_OFFSET})
 
     # Verify that partition B is currently active
     require-uboot-variable(uboot-env, "active_system", "b")
@@ -351,8 +373,8 @@ task update.a {
 
 # This firmware task updates system B when system A is currently active
 task update.b {
-    # Verify we are running from system A
-    require-partition-offset(1, ${ROOTFS_A_PART_OFFSET})
+    # Verify we are running from system A (rootfs_a is partition index 2)
+    require-partition-offset(2, ${ROOTFS_A_PART_OFFSET})
 
     # Verify that partition A is currently active
     require-uboot-variable(uboot-env, "active_system", "a")

--- a/system_kontron-albl-imx8mm/rootfs_overlay/etc/erlinit.config
+++ b/system_kontron-albl-imx8mm/rootfs_overlay/etc/erlinit.config
@@ -54,11 +54,11 @@
 #       the history is loaded. If this mount fails due to corruption, etc.,
 #       grisp_runtime will auto-format it. Your applications will need to handle
 #       initializing any expected files and folders.
--m /dev/rootdisk0p1:/boot:vfat:ro,nodev,noexec,nosuid:
+-m /dev/rootdisk0p2:/boot:vfat:ro,nodev,noexec,nosuid:
 -m tmpfs:/root:tmpfs::mode=0700,size=1M
 -m tmpfs:/var/log:tmpfs:nodev,noexec,nosuid:mode=0755,size=16M
 
---pre-run-exec "/sbin/early-init.sh"
+--pre-run-exec "/sbin/early-init.sh /dev/rootdisk0p5"
 
 # Erlang release search path
 -r /srv/erlang

--- a/system_kontron-albl-imx8mm/uboot/uboot.env
+++ b/system_kontron-albl-imx8mm/uboot/uboot.env
@@ -65,17 +65,17 @@ alloy_bootcmd=\
 # Boot from eMMC with A/B software update
 alloy_bootcmd_mmc0=\
 	devnum=0;\
-	devpart=1;\
+	devpart=2;\
 	run alloy_boot_ab;
 
 # Boot from SD card
 alloy_bootcmd_mmc1=\
 	devnum=1;\
-	devpart=1;\
+	devpart=2;\
 	run alloy_boot_simple;
 
 alloy_boot_simple=\
-	setenv bootargs root=/dev/mmcblk${devnum}p2 ${bootargs_base} ${bootargs_extra} alloy.boot_id=sd-card;\
+	setenv bootargs root=/dev/mmcblk${devnum}p3 ${bootargs_base} ${bootargs_extra} alloy.boot_id=sd-card;\
 	if load mmc ${devnum}:${devpart} ${loadaddr} ${image_base}; then\
 		bootm ${loadaddr};\
 	fi;
@@ -103,33 +103,33 @@ alloy_boot_ab=\
 	if test ${valid_system} = a && test ${update_available} = 0 && test ${update_fallback} = 0; then\
 		setenv active_system a;\
 		setenv image ${image_base}_A;\
-		setenv bootargs root=/dev/mmcblk${devnum}p2 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-a;\
-		echo Booting system A: /dev/mmcblk${devnum}p2;\
+		setenv bootargs root=/dev/mmcblk${devnum}p3 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-a;\
+		echo Booting system A: /dev/mmcblk${devnum}p3;\
 	elif test ${valid_system} = b && test ${update_available} = 0 && test ${update_fallback} = 0; then\
 		setenv active_system b;\
 		setenv image ${image_base}_B;\
-		setenv bootargs root=/dev/mmcblk${devnum}p3 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-b;\
-		echo Booting system B: /dev/mmcblk${devnum}p3;\
+		setenv bootargs root=/dev/mmcblk${devnum}p4 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-b;\
+		echo Booting system B: /dev/mmcblk${devnum}p4;\
 	elif test ${valid_system} = a && test ${update_fallback} -gt 0; then\
 		setenv active_system a;\
 		setenv image ${image_base}_A;\
-		setenv bootargs root=/dev/mmcblk${devnum}p2 ${bootargs_base} ${bootargs_extra}  alloy.boot_id=system-a fallback;\
-		echo Falling back to system A: /dev/mmcblk${devnum}p2;\
+		setenv bootargs root=/dev/mmcblk${devnum}p3 ${bootargs_base} ${bootargs_extra}  alloy.boot_id=system-a fallback;\
+		echo Falling back to system A: /dev/mmcblk${devnum}p3;\
 	elif test ${valid_system} = b && test ${update_fallback} -gt 0; then\
 		setenv active_system b;\
 		setenv image ${image_base}_B;\
-		setenv bootargs root=/dev/mmcblk${devnum}p3 ${bootargs_base} alloy.boot_id=system-b fallback;\
-		echo Falling back to system B: /dev/mmcblk${devnum}p3;\
+		setenv bootargs root=/dev/mmcblk${devnum}p4 ${bootargs_base} alloy.boot_id=system-b fallback;\
+		echo Falling back to system B: /dev/mmcblk${devnum}p4;\
 	elif test ${valid_system} = a && test ${update_available} = 1; then\
 		setenv active_system b;\
 		setenv image ${image_base}_B;\
-		setenv bootargs root=/dev/mmcblk${devnum}p3 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-b alloy.upgrading=true;\
-		echo Upgrading to system B: /dev/mmcblk${devnum}p3;\
+		setenv bootargs root=/dev/mmcblk${devnum}p4 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-b alloy.upgrading=true;\
+		echo Upgrading to system B: /dev/mmcblk${devnum}p4;\
 	elif test ${valid_system} = b && test ${update_available} = 1; then\
 		setenv active_system a;\
 		setenv image ${image_base}_A;\
-		setenv bootargs root=/dev/mmcblk${devnum}p2 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-a alloy.upgrading=true;\
-		echo Upgrading to system A: /dev/mmcblk${devnum}p2;\
+		setenv bootargs root=/dev/mmcblk${devnum}p3 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-a alloy.upgrading=true;\
+		echo Upgrading to system A: /dev/mmcblk${devnum}p3;\
 	else\
 		echo "FATAL: Unexpected system update context";\
 		echo "  valid_system=${valid_system}";\
@@ -137,8 +137,8 @@ alloy_boot_ab=\
 		echo "  update_fallback=${update_fallback}";\
 		setenv active_system a;\
 		setenv image ${image_base}_A;\
-		setenv bootargs root=/dev/mmcblk${devnum}p2 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-a recovery;\
-		echo "Emergency boot to system A: /dev/mmcblk${devnum}p2";\
+		setenv bootargs root=/dev/mmcblk${devnum}p3 ${bootargs_base} ${bootargs_extra} alloy.boot_id=system-a recovery;\
+		echo "Emergency boot to system A: /dev/mmcblk${devnum}p3";\
 	fi\
 	if load mmc ${devnum}:${devpart} ${loadaddr} ${image}; then\
 		bootm ${loadaddr};\


### PR DESCRIPTION
Switch to using GPT for disk partitions, in prevision of needed an extra partition for the Secure Enclave later on.

To test you need to rebuild the SDK, forcing the rebuild of host-uboot-tools:

```
vagrant provision
./build-sdk.sh -Kr -p host-uboot-tools kontron-albl-imx8mm
./build-project.sh -Kc kontron-albl-imx8mm samples/hello_elixir
./build-firmware.sh -Kc kontron-albl-imx8mm hello_elixir
fwup -a -d /dev/disk2 -i artefacts/hello_elixir-kontron-albl-imx8mm.fw -t sdcard
```
